### PR TITLE
Increase Alloy OTel max_recv_msg_size

### DIFF
--- a/config.alloy.sample
+++ b/config.alloy.sample
@@ -9,7 +9,9 @@ logging {
 
 otelcol.receiver.otlp "default" {
         // configures the default grpc endpoint "0.0.0.0:4317"
-        grpc { }
+        grpc {
+          max_recv_msg_size = "128MiB"  
+        }
         // configures the default http/protobuf endpoint "0.0.0.0:4318"
         http { }
 


### PR DESCRIPTION
Setting to 128 MiB based on what I've seen in some larger customer environments.  
