### PR TITLE
Add format_metric=otel for internal ktranslate health metrics

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,7 @@ services:
       - alloy
     command:
       - --format=otel
+      - --format_metric=otel
       - --otel.protocol=grpc
       - --otel.endpoint=http://alloy:4317/
       - --nf.source=${NF_SOURCE}
@@ -46,6 +47,7 @@ services:
       - alloy
     command:
       - --format=otel
+      - --format_metric=otel
       - --otel.protocol=grpc
       - --otel.endpoint=http://alloy:4317/
       - --snmp=/snmp.yaml
@@ -76,6 +78,7 @@ services:
       - alloy
     command:
       - --format=otel
+      - --format_metric=otel
       - --otel.protocol=grpc
       - --otel.endpoint=http://alloy:4317/
       - --syslog.source=${SYSLOG_SOURCE}


### PR DESCRIPTION
## Summary
- Adds \--format_metric=otel\ to \ktranslate_flow\, \ktranslate_snmp\, and \ktranslate_syslog\ in \compose.yaml\.
- Internal metrics emitted via \--metrics=jchf\ were previously formatted as \
ew_relic_metric\ and silently dropped by the \otel\ sink.

## Branch context
Targets **main** (single SNMP poller / CIDR discovery layout).

## Test plan
- [ ] \docker compose up -d\ starts all services
- [ ] After ~2 minutes, query Grafana/Prometheus for \kentik_ktranslate_*\ internal metrics (e.g. \jchfq\, \inputq\, \device_metrics\)
- [ ] SNMP device metrics (\kentik_snmp_*\) still present


Made with [Cursor](https://cursor.com)